### PR TITLE
Include --platform=linux/amd64

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+VERSION 0.6
+FROM --platform=linux/amd64 ubuntu:20.04
 
 hello-world-binary:
     WORKDIR /code


### PR DESCRIPTION
This example produces an amd64 binary only; as a result M1 users running
without changing the platform will get an error.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>